### PR TITLE
refactor: force action added to symlink creation task

### DIFF
--- a/files/assertions/criteria/symlinks_criteria.json
+++ b/files/assertions/criteria/symlinks_criteria.json
@@ -23,6 +23,10 @@
                     "group":
                     {
                         "$ref": "#/definitions/non-empty-string"
+                    },
+                    "force":
+                    {
+                        "type": "boolean"
                     }
                 },
                 "required":

--- a/tasks/make_link.yml
+++ b/tasks/make_link.yml
@@ -11,6 +11,21 @@
     - link.destination.make is defined
     - link.destination.make
 
+- name: hth | symlink | stat location
+  ansible.builtin.stat:
+    path: "{{ link.location.path }}"
+  register: destination
+
+- name: hth | symlink | remove location
+  ansible.builtin.file:
+    path: "{{ link.location.path }}"
+    state: absent
+  when:
+    - link.location.force is defined
+    - link.location.force
+    - destination.stat.exists
+    - destination.stat.isdir or (destination.stat.islnk and destination.stat.lnk_source != "{{ link.destination.path }}")
+
 - name: hth | symlink | create link
   ansible.builtin.file:
     src: "{{ link.destination.path }}"
@@ -20,4 +35,3 @@
     group: "{{ link.location.group }}"
     modification_time: preserve
     access_time: preserve
-


### PR DESCRIPTION
`force` field added to `location` object to indicate that pre existing directories or links that are discovered at `location.path` should be removed before a symlink creation takes place. If there is already a pre-existing symlink at `location.path` that already points to `destination.path` then it will not be removed.